### PR TITLE
Fix IPv6 Router Solicitation replies

### DIFF
--- a/nfdhcpd
+++ b/nfdhcpd
@@ -126,6 +126,26 @@ DHCP_REQRESP = {
     DHCPINFORM: DHCPACK,
     }
 
+def ipv62mac(ipv6):
+    # remove subnet info if given
+    subnetIndex = ipv6.find("/")
+    if subnetIndex != -1:
+        ipv6 = ipv6[:subnetIndex]
+
+    ipv6Parts = ipv6.split(":")
+    macParts = []
+    for ipv6Part in ipv6Parts[-4:]:
+        while len(ipv6Part) < 4:
+            ipv6Part = "0" + ipv6Part
+        macParts.append(ipv6Part[:2])
+        macParts.append(ipv6Part[-2:])
+
+    # modify parts to match MAC value
+    macParts[0] = "%02x" % (int(macParts[0], 16) ^ 2)
+    del macParts[4]
+    del macParts[3]
+
+    return ":".join(macParts)
 
 def get_indev(payload):
     try:
@@ -790,9 +810,9 @@ class VMNetProxy(object):  # pylint: disable=R0902
         pkt = IPv6(payload.get_data())
         #logging.debug(pkt.show())
         try:
-            mac = pkt.lladdr
+            mac = ipv62mac(pkt.src)
         except:
-            logging.debug(" - RS: Cannot obtain lladdr")
+            logging.debug(" - RS: Cannot obtain MAC")
             return
 
         indev = get_indev(payload)


### PR DESCRIPTION
The code was trying to find pkt.lladdr but this doesn't exist in an RS packet.
Instead pkt.src exists which has a value like: fe80::a800:ff:fab1:abcd So we
need to convert this address (which is a link local address) to a mac address
and use that mac.

Introduce ipv62mac function which does the ipv6 address to mac conversion.
